### PR TITLE
Allow multiple commands per pane

### DIFF
--- a/src/project_config/project.rs
+++ b/src/project_config/project.rs
@@ -126,6 +126,6 @@ windows:
         assert_eq!(windows.len(), 1);
         let first = windows.get(0).unwrap();
         assert_eq!(first.name, window_name);
-        assert_eq!(first.panes, vec![Some(window_command)]);
+        assert_eq!(first.panes, vec![Some(vec![window_command])]);
     }
 }

--- a/src/tmux/project.rs
+++ b/src/tmux/project.rs
@@ -256,14 +256,16 @@ impl<'a> TmuxProject<'a> {
                     });
                 })
             }
-            if let Some(pane_cmd) = pane {
-                commands.push(Commands::SendKeys {
-                    command: pane_cmd.clone(),
-                    session_name: project_name,
-                    window_index: window_idx,
-                    pane_index: Some(pane_with_base_idx),
-                    comment: None,
-                });
+            if let Some(pane_commands) = pane {
+                for pan_cmd in pane_commands.iter() {
+                    commands.push(Commands::SendKeys {
+                        command: pan_cmd.clone(),
+                        session_name: project_name,
+                        window_index: window_idx,
+                        pane_index: Some(pane_with_base_idx),
+                        comment: None,
+                    });
+                }
             }
         });
 


### PR DESCRIPTION
Allows specifying multiple commands per pane which translates to separate `send-keys` calls.

This is useful when commands cannot be chained with `&&` or `;` because of a shell context change e.g.:
+ SSH to another machine
+ Active Python virtual environments 
+ Trigger tools that modify active shell context like `asdf` or `rtx` that trigger current directory change 

One step towards [`tmuxinator` feature parity](https://github.com/tmuxinator/tmuxinator#passing-directly-to-send-keys) :wink:

## Example

```yaml
project_name: my-project
project_root: ~/projects/my-project
windows:
  - main:
      panes:
        - vim .
        - worker:
          - cd ~/projects/worker
          - source .cfg/some-shell-change
          - worker start 
        - remote-logs:
          - ssh me@example.com
          - cd /var/logs
          - tail -f my-project.debug.log
``` 

NB: the "pane name" like `worker` and `remote-logs` in here is not used but makes the YAML easier to write and read than a nested list of lists

_P.S. thanks for a great tool! :bow:_