### PR TITLE
Implement loading project from path for certain sub commands

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -47,8 +47,8 @@ pub(crate) fn list_projects() -> Result<(), AppError> {
 }
 
 /// Parses the project file and prints the shell commands for session creation.
-pub(crate) fn debug_project(project_name: &str) -> Result<(), AppError> {
-    let entries = config::get_project_yaml(project_name)?;
+pub(crate) fn debug_project(project_name: &str, is_path: bool) -> Result<(), AppError> {
+    let entries = config::get_entries(project_name, is_path)?;
     let project = ProjectConfig::try_from(entries)?;
     let tmux = TmuxProject::new(&project)?;
     println!("{tmux}");
@@ -56,10 +56,10 @@ pub(crate) fn debug_project(project_name: &str) -> Result<(), AppError> {
 }
 
 /// Parses the project file, runs the commands to create the tmux session.
-pub fn run_project(project_name: &str) -> Result<(), AppError> {
+pub fn run_project(project_name: &str, is_path: bool) -> Result<(), AppError> {
+    let entries = config::get_entries(project_name, is_path)?;
     println!("Starting project {project_name}");
 
-    let entries = config::get_project_yaml(project_name)?;
     let project = ProjectConfig::try_from(entries)?;
     let tmux = TmuxProject::new(&project)?;
     Ok(tmux.run()?)
@@ -197,7 +197,8 @@ pub(crate) fn copy_project(existing: &str, new: &str) -> Result<(), AppError> {
 }
 
 /// Kills the project's session.
-pub(crate) fn stop(project_name: &str) -> Result<(), AppError> {
+pub(crate) fn stop(project_name: &str, is_path: bool) -> Result<(), AppError> {
+    let entries = config::get_entries(project_name, is_path)?;
     let entries = config::get_project_yaml(project_name)?;
     let project = ProjectConfig::try_from(entries)?;
     let tmux = TmuxProject::new(&project)?;

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -7,15 +7,36 @@ pub(crate) fn get_cli_command_parser() -> Command {
         .arg_required_else_help(true)
         .subcommand_negates_reqs(true)
         .arg(Arg::new("project").help("Project name").required(true))
+        .arg(
+            Arg::new("path")
+                .long("path")
+                .short('p')
+                .action(ArgAction::SetTrue)
+                .help("Load from path instead of project"),
+        )
         .subcommand(Command::new("list").about("List all projects"))
         .subcommand(
             Command::new("debug")
                 .about("Output shell commands for a project")
+                .arg(
+                    Arg::new("path")
+                        .long("path")
+                        .short('p')
+                        .action(ArgAction::SetTrue)
+                        .help("Load from path instead of project"),
+                )
                 .arg(Arg::new("project").help("Project name").required(true)),
         )
         .subcommand(
             Command::new("run")
                 .about("Run the project commands")
+                .arg(
+                    Arg::new("path")
+                        .long("path")
+                        .short('p')
+                        .action(ArgAction::SetTrue)
+                        .help("Load from path instead of project"),
+                )
                 .arg(Arg::new("project").help("Project name").required(true)),
         )
         .subcommand(
@@ -31,6 +52,13 @@ pub(crate) fn get_cli_command_parser() -> Command {
         .subcommand(
             Command::new("edit")
                 .about("Edit an existing project")
+                .arg(
+                    Arg::new("path")
+                        .long("path")
+                        .short('p')
+                        .action(ArgAction::SetTrue)
+                        .help("Load from path instead of project"),
+                )
                 .arg(Arg::new("project").help("Project name").required(true)),
         )
         .subcommand(
@@ -52,6 +80,13 @@ pub(crate) fn get_cli_command_parser() -> Command {
         .subcommand(
             Command::new("stop")
                 .about("Stop the project's session")
+                .arg(
+                    Arg::new("path")
+                        .long("path")
+                        .short('p')
+                        .action(ArgAction::SetTrue)
+                        .help("Load from path instead of project"),
+                )
                 .arg(Arg::new("project").help("Project name").required(true)),
         )
         .subcommand(Command::new("doctor").about("Check your configuration"))

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -1,43 +1,36 @@
 //! CLI arguments parser.
 use clap::{command, Arg, ArgAction, Command};
+pub(crate) fn arg_is_path() -> Arg {
+    Arg::new("path")
+        .long("path")
+        .short('p')
+        .action(ArgAction::SetTrue)
+        .help("Load from path instead of project")
+}
+
+pub(crate) fn arg_project() -> Arg {
+    Arg::new("project").help("Project name").required(true)
+}
 
 /// Returns [`clap::Command`] for the CLI application.
 pub(crate) fn get_cli_command_parser() -> Command {
     command!()
         .arg_required_else_help(true)
         .subcommand_negates_reqs(true)
-        .arg(Arg::new("project").help("Project name").required(true))
-        .arg(
-            Arg::new("path")
-                .long("path")
-                .short('p')
-                .action(ArgAction::SetTrue)
-                .help("Load from path instead of project"),
-        )
+        .arg(arg_project())
+        .arg(arg_is_path())
         .subcommand(Command::new("list").about("List all projects"))
         .subcommand(
             Command::new("debug")
                 .about("Output shell commands for a project")
-                .arg(
-                    Arg::new("path")
-                        .long("path")
-                        .short('p')
-                        .action(ArgAction::SetTrue)
-                        .help("Load from path instead of project"),
-                )
-                .arg(Arg::new("project").help("Project name").required(true)),
+                .arg(arg_is_path())
+                .arg(arg_project()),
         )
         .subcommand(
             Command::new("run")
                 .about("Run the project commands")
-                .arg(
-                    Arg::new("path")
-                        .long("path")
-                        .short('p')
-                        .action(ArgAction::SetTrue)
-                        .help("Load from path instead of project"),
-                )
-                .arg(Arg::new("project").help("Project name").required(true)),
+                .arg(arg_is_path())
+                .arg(arg_project()),
         )
         .subcommand(
             Command::new("copy")
@@ -52,24 +45,18 @@ pub(crate) fn get_cli_command_parser() -> Command {
         .subcommand(
             Command::new("edit")
                 .about("Edit an existing project")
-                .arg(
-                    Arg::new("path")
-                        .long("path")
-                        .short('p')
-                        .action(ArgAction::SetTrue)
-                        .help("Load from path instead of project"),
-                )
-                .arg(Arg::new("project").help("Project name").required(true)),
+                .arg(arg_is_path())
+                .arg(arg_project()),
         )
         .subcommand(
             Command::new("delete")
                 .about("Delete an existing project")
-                .arg(Arg::new("project").help("Project name").required(true)),
+                .arg(arg_project()),
         )
         .subcommand(
             Command::new("new")
                 .about("Create a new project")
-                .arg(Arg::new("project").help("Project name").required(true))
+                .arg(arg_project())
                 .arg(
                     Arg::new("blank")
                         .long("blank")
@@ -80,14 +67,8 @@ pub(crate) fn get_cli_command_parser() -> Command {
         .subcommand(
             Command::new("stop")
                 .about("Stop the project's session")
-                .arg(
-                    Arg::new("path")
-                        .long("path")
-                        .short('p')
-                        .action(ArgAction::SetTrue)
-                        .help("Load from path instead of project"),
-                )
-                .arg(Arg::new("project").help("Project name").required(true)),
+                .arg(arg_is_path())
+                .arg(arg_project()),
         )
         .subcommand(Command::new("doctor").about("Check your configuration"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,17 +14,22 @@ fn main() -> Result<(), AppErrorForDisplay> {
     let matches = cli::get_cli_command_parser().get_matches();
 
     if let Some(project_name) = matches.get_one::<String>("project") {
-        return actions::run_project(project_name).map_err(|e| e.into());
+        let is_path = matches.get_one::<bool>("path").unwrap();
+        return actions::run_project(project_name, *is_path).map_err(|e| e.into());
     }
 
     match matches.subcommand() {
         Some(("list", _)) => actions::list_projects(),
         Some(("doctor", _)) => actions::check_config(),
         Some(("debug", debug_matches)) => {
-            actions::debug_project(debug_matches.get_one::<String>("project").unwrap())
+            let project = debug_matches.get_one::<String>("project").unwrap();
+            let is_path = debug_matches.get_one::<bool>("path").unwrap();
+            actions::debug_project(project, *is_path)
         }
         Some(("run", run_matches)) => {
-            actions::run_project(run_matches.get_one::<String>("project").unwrap())
+            let project = run_matches.get_one::<String>("project").unwrap();
+            let is_path = run_matches.get_one::<bool>("path").unwrap();
+            actions::run_project(project, *is_path)
         }
         Some(("edit", edit_matches)) => {
             actions::edit_project(edit_matches.get_one::<String>("project").unwrap())
@@ -41,7 +46,9 @@ fn main() -> Result<(), AppErrorForDisplay> {
             copy_matches.get_one::<String>("new").unwrap(),
         ),
         Some(("stop", stop_matches)) => {
-            actions::stop(stop_matches.get_one::<String>("project").unwrap())
+            let project = stop_matches.get_one::<String>("project").unwrap();
+            let is_path = stop_matches.get_one::<bool>("path").unwrap();
+            actions::stop(project, *is_path)
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
Adds -p/--path for
- [x] run
- [x] debug
- [x] stop
- [ ] new
- [ ] delete
- [ ] edit
- [ ] copy

This allows for example checking in projects into git repos without the need to copy them around.

Example:
`rusmux run -p ./some-project.yml`